### PR TITLE
Fix typo in site description

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -9,7 +9,7 @@ title = "Six-Sided Vice"
 
 [params]
   defaultTheme = "dark"
-  description = "These are my favrourite plastic children. Please do not tell the others, though."
+  description = "These are my favourite plastic children. Please do not tell the others, though."
   title = "Ross' hobby gallery"
   logo = "logo.png"
   [params.author]


### PR DESCRIPTION
Description possibly not visible on site but definitely used in social media embeds